### PR TITLE
adds support for HTTP_PROXY and HTTPS_PROXY env vars

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -7,19 +7,32 @@
     Released under the MIT license.
 */
 
-var http        = require('http'),
-    https       = require('https'),
-    querystring = require('querystring'),
-    Buffer      = require('buffer').Buffer,
-    util        = require('util');
+var http            = require('http'),
+    https           = require('https'),
+    querystring     = require('querystring'),
+    Buffer          = require('buffer').Buffer,
+    util            = require('util'),
+    HttpsProxyAgent = require('https-proxy-agent');
 
 var REQUEST_LIBS = {
     http: http,
     https: https
 };
 
+var create_proxy_agent = function() {
+    var proxyPath = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+
+    if (proxyPath) {
+        console.log('proxy', proxyPath);
+        return new HttpsProxyAgent(proxyPath);
+    }
+
+    return;
+}
+
 var create_client = function(token, config) {
     var metrics = {};
+    var proxyAgent = create_proxy_agent();
 
     if(!token) {
         throw new Error("The Mixpanel Client needs a Mixpanel token: `init(token)`");
@@ -76,6 +89,11 @@ var create_client = function(token, config) {
             headers: {}
         };
 
+        if (proxyAgent) {
+            console.log('setting agent');
+            request_options.agent = proxyAgent;
+        }
+        
         if (metrics.config.test) { request_data.test = 1; }
 
         var query = querystring.stringify(request_data);
@@ -83,6 +101,8 @@ var create_client = function(token, config) {
         request_options.path = [endpoint,"?",query].join("");
 
         request_lib.get(request_options, function(res) {
+            console.log('here');
+
             var data = "";
             res.on('data', function(chunk) {
                data += chunk;
@@ -108,6 +128,7 @@ var create_client = function(token, config) {
                 callback(e);
             });
         }).on('error', function(e) {
+            console.log('get failed', e);
             if (metrics.config.debug) {
                 console.log("Got Error: " + e.message);
             }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   },
   "devDependencies": {
     "nodeunit": "^0.9.1",
+    "proxyquire": "^1.7.11",
     "sinon": "^1.14.1"
+  },
+  "dependencies": {
+    "https-proxy-agent": "^1.0.0"
   }
 }


### PR DESCRIPTION
This lib won't be able to run from behind a proxy. This PR adds detection of HTTP_PROXY and HTTPS_PROXY environment variables and if found, will create a proxy agent for the request.

